### PR TITLE
fix typo

### DIFF
--- a/02-HTMLWidget.md
+++ b/02-HTMLWidget.md
@@ -18,7 +18,7 @@ The `<HTMLWidget>` tag is the top level tag of all MuCow files.
 | Name | Values | Description |
 |---|---|---|
 | name | String | **Required.** The name of the widget. Will be displayed in the options dialog, and also in the control strip |
-| formatNum | 3&nbsp;(Muse&nbsp;2014.3+) <br> 2&nbsp;(Muse&nbsp;2014.0+) <br> 1&nbsp;(Muse&nbsp;7.0+) | **Required.** The format number of this file. Current Muse versions support format 3 and below. |
+| formatNumber | 3&nbsp;(Muse&nbsp;2014.3+) <br> 2&nbsp;(Muse&nbsp;2014.0+) <br> 1&nbsp;(Muse&nbsp;7.0+) | **Required.** The format number of this file. Current Muse versions support format 3 and below. |
 | localization | `none` <br> `stringTable` | **Required.** The type of [localization][1] for this widget |
 | termsURL | URL | The URL to a 'Terms of Use' page. A link to this URL will appear in options dialog if non-empty. If you specify termsURL, do not specify termsText |
 | termsText | String | HTML text to appear in a 'Terms of Use' dialog. Text may include links to URLs. If you specify termsText, do not specify termsURL |

--- a/03-Parameter Tags.md
+++ b/03-Parameter Tags.md
@@ -239,7 +239,7 @@ Informative text to show in the On-Object UI, which can optionally link to a URL
 ### Required Attributes
 | Name | Values | Description |
 |---|---|---|---|
-| value | String | The text to display to the user |
+| label | String | The text to display to the user |
 
 ### Optional Attributes
 | Name | Values | Description |


### PR DESCRIPTION
Fixes typo "FormatNum" attribute in MucowWidget Tag
